### PR TITLE
Fix navigation by removing duplicate base path handling

### DIFF
--- a/src/components/comparisons/ComparisonCreator.tsx
+++ b/src/components/comparisons/ComparisonCreator.tsx
@@ -284,8 +284,7 @@ export default function ComparisonCreator() {
     localStorage.setItem(`comparison-${hash}`, JSON.stringify(preview));
     
     // Navigate to the comparison page
-    const basePath = import.meta.env.DEV ? '' : '/forkcast';
-    navigate(`${basePath}/compare/${hash}`);
+    navigate(`/compare/${hash}`);
   };
 
   const copyToClipboard = (text: string) => {
@@ -322,7 +321,7 @@ export default function ComparisonCreator() {
               const url = loadExampleComparison();
               navigate(url);
             }}
-            className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+            className="text-blue-600 dark:text-blue-400 hover:underline font-medium cursor-pointer"
           >
             View Example: ePBS vs 6-Second Slots →
           </button>

--- a/src/components/comparisons/ComparisonViewer.tsx
+++ b/src/components/comparisons/ComparisonViewer.tsx
@@ -48,10 +48,7 @@ export default function ComparisonViewer() {
             {error}
           </h2>
           <button
-            onClick={() => {
-              const basePath = import.meta.env.DEV ? '' : '/forkcast';
-              navigate(`${basePath}/compare/new`);
-            }}
+            onClick={() => navigate('/compare/new')}
             className="mt-4 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
           >
             Create New Comparison
@@ -78,10 +75,7 @@ export default function ComparisonViewer() {
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-4">
           <button
-            onClick={() => {
-              const basePath = import.meta.env.DEV ? '' : '/forkcast';
-              navigate(`${basePath}/`);
-            }}
+            onClick={() => navigate('/')}
             className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
           >
             ← Back to Forkcast

--- a/src/components/comparisons/ExampleLoader.tsx
+++ b/src/components/comparisons/ExampleLoader.tsx
@@ -8,9 +8,8 @@ const EXAMPLE_COMPARISON = exampleComparison;
 export function loadExampleComparison() {
   const hash = 'example-epbs-6s';
   localStorage.setItem(`comparison-${hash}`, JSON.stringify(EXAMPLE_COMPARISON));
-  // In development, we don't have the base path
-  const basePath = import.meta.env.DEV ? '' : '/forkcast';
-  return `${basePath}/compare/${hash}`;
+  // Return just the path without base - Router handles the base path
+  return `/compare/${hash}`;
 }
 
 export default function ExampleLoader() {


### PR DESCRIPTION
- Remove manual base path additions in navigate() calls
- React Router already handles base path through basename prop
- Fixes example comparison button not working
- Simplifies all navigation code

🤖 Generated with [Claude Code](https://claude.ai/code)