### PR TITLE
fix: Implement hash-based routing for GitHub Pages compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,21 +40,6 @@
       })();
     </script>
     <!-- End Matomo Code -->
-
-    <!-- GitHub Pages SPA redirect handling -->
-    <script type="text/javascript">
-      // Handle GitHub Pages SPA redirect
-      (function(l) {
-        if (l.search[1] === '/' ) {
-          var decoded = l.search.slice(1).split('&').map(function(s) {
-            return s.replace(/~and~/g, '&')
-          }).join('?');
-          window.history.replaceState(null, null,
-              l.pathname.slice(0, -1) + decoded + l.hash
-          );
-        }
-      }(window.location))
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -4,14 +4,11 @@
     <meta charset="utf-8">
     <title>Forkcast</title>
     <script type="text/javascript">
-      // SPA redirect for custom domain
-      // Redirect to root and let React Router handle the routing
-      var l = window.location;
-      var path = l.pathname + l.search + l.hash;
-      l.replace(l.origin + '/?redirect=' + encodeURIComponent(path));
+      // Simple redirect to home for hash routing
+      window.location.replace(window.location.origin + '/forkcast/');
     </script>
   </head>
   <body>
-    <p>Redirecting...</p>
+    <p>Redirecting to Forkcast...</p>
   </body>
-</html> 
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 import PublicNetworkUpgradePage from './components/PublicNetworkUpgradePage';
 import HomePage from './components/HomePage';
@@ -10,29 +10,6 @@ import ExternalRedirect from './components/ExternalRedirect';
 import ComparisonCreator from './components/comparisons/ComparisonCreator';
 import ComparisonViewer from './components/comparisons/ComparisonViewer';
 import ExampleLoader from './components/comparisons/ExampleLoader';
-
-function RedirectHandler() {
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  useEffect(() => {
-    // Check for redirect parameter from 404.html
-    const urlParams = new URLSearchParams(location.search);
-    const redirect = urlParams.get('redirect');
-
-    if (redirect) {
-      // Remove the redirect parameter and navigate to the target path
-      urlParams.delete('redirect');
-      const newSearch = urlParams.toString();
-      const newPath = redirect + (newSearch ? '?' + newSearch : '');
-
-      // Use replace to avoid adding to browser history
-      navigate(newPath, { replace: true });
-    }
-  }, [navigate, location.search]);
-
-  return null;
-}
 
 function AnalyticsTracker() {
   const location = useLocation();
@@ -56,8 +33,7 @@ function App() {
 
   return (
     <ThemeProvider>
-      <Router basename={import.meta.env.DEV ? "" : "/forkcast"}>
-        <RedirectHandler />
+      <Router>
         <AnalyticsTracker />
         <Routes>
           <Route path="/" element={<HomePage />} />

--- a/src/components/comparisons/ComparisonViewer.tsx
+++ b/src/components/comparisons/ComparisonViewer.tsx
@@ -91,10 +91,7 @@ export default function ComparisonViewer() {
 
       <div className="mt-6 text-center">
         <button
-          onClick={() => {
-            const basePath = import.meta.env.DEV ? '' : '/forkcast';
-            navigate(`${basePath}/compare/new`);
-          }}
+          onClick={() => navigate('/compare/new')}
           className="text-blue-600 dark:text-blue-400 hover:underline"
         >
           Create your own comparison →


### PR DESCRIPTION
- Switch from BrowserRouter to HashRouter to eliminate redirect issues
- Remove complex redirect handling logic from App.tsx and HTML files
- Simplify 404.html to just redirect to home page
- URLs now use hash fragments (e.g., /forkcast/#/compare/new)
- Maintains all existing functionality with localStorage
- Provides smoother browsing experience without visible redirects

🤖 Generated with [Claude Code](https://claude.ai/code)